### PR TITLE
Halving link time while keeping run time performance

### DIFF
--- a/Gigantua/Gigantua.cpp
+++ b/Gigantua/Gigantua.cpp
@@ -44,7 +44,7 @@ public:
 #define IFPRN if constexpr (ENABLEPRINT) 
 
 	template<class BoardStatus status, int depth>
-	static _Inline void Kingmove(const Board& brd, uint64_t from, uint64_t to)
+	static void Kingmove(const Board& brd, uint64_t from, uint64_t to)
 	{
 		Board next = Board::Move<BoardPiece::King, status.WhiteMove>(brd, from, to, to & Enemy<status.WhiteMove>(brd));
 		IFPRN std::cout << "Kingmove:\n" << _map(from, to, brd, next) << "\n";
@@ -54,7 +54,7 @@ public:
 	}
 
 	template<class BoardStatus status, int depth>
-	static _Inline void KingCastle(const Board& brd, uint64_t kingswitch, uint64_t rookswitch)
+	static void KingCastle(const Board& brd, uint64_t kingswitch, uint64_t rookswitch)
 	{
 		Board next = Board::MoveCastle<status.WhiteMove>(brd, kingswitch, rookswitch);
 		IFPRN std::cout << "KingCastle:\n" << _map(kingswitch, rookswitch, brd, next) << "\n";
@@ -63,7 +63,7 @@ public:
 	}
 
 	template<class BoardStatus status, int depth>
-	static _Inline void PawnCheck(map eking, uint64_t to) {
+	static void PawnCheck(map eking, uint64_t to) {
 		constexpr bool white = status.WhiteMove;
 		map pl = Pawn_AttackLeft<white>(to & Pawns_NotLeft());
 		map pr = Pawn_AttackRight<white>(to & Pawns_NotRight());
@@ -72,7 +72,7 @@ public:
 	}
 
 	template<class BoardStatus status, int depth>
-	static _Inline void KnightCheck(map eking, uint64_t to) {
+	static void KnightCheck(map eking, uint64_t to) {
 		constexpr bool white = status.WhiteMove;
 
 		if (Lookup::Knight(SquareOf(eking)) & to) Movestack::Check_Status[depth - 1] = to;
@@ -80,7 +80,7 @@ public:
 	
 
 	template<class BoardStatus status, int depth>
-	static _Inline void Pawnmove(const Board& brd, uint64_t from, uint64_t to)
+	static void Pawnmove(const Board& brd, uint64_t from, uint64_t to)
 	{
 		Board next = Board::Move<BoardPiece::Pawn, status.WhiteMove, false>(brd, from, to);
 		IFPRN std::cout << "Pawnmove:\n" << _map(from, to, brd, next) << "\n";
@@ -91,7 +91,7 @@ public:
 	}
 
 	template<class BoardStatus status, int depth>
-	static _Inline void Pawnatk(const Board& brd, uint64_t from, uint64_t to)
+	static void Pawnatk(const Board& brd, uint64_t from, uint64_t to)
 	{
 		Board next = Board::Move<BoardPiece::Pawn, status.WhiteMove, true>(brd, from, to);
 		IFPRN std::cout << "Pawntake:\n" << _map(from, to, brd, next) << "\n";
@@ -102,7 +102,7 @@ public:
 	}
 
 	template<class BoardStatus status, int depth>
-	static _Inline void PawnEnpassantTake(const Board& brd, uint64_t from, uint64_t enemy, uint64_t to)
+	static void PawnEnpassantTake(const Board& brd, uint64_t from, uint64_t enemy, uint64_t to)
 	{
 		Board next = Board::MoveEP<status.WhiteMove>(brd, from, enemy, to);
 		IFPRN std::cout << "PawnEnpassantTake:\n" << _map(from | enemy, to, brd, next) << "\n";
@@ -113,7 +113,7 @@ public:
 	}
 
 	template<class BoardStatus status, int depth>
-	static _Inline void Pawnpush(const Board& brd, uint64_t from, uint64_t to)
+	static void Pawnpush(const Board& brd, uint64_t from, uint64_t to)
 	{
 		Board next = Board::Move <BoardPiece::Pawn, status.WhiteMove, false>(brd, from, to);
 		IFPRN std::cout << "Pawnpush:\n" << _map(from, to, brd, next) << "\n";
@@ -126,7 +126,7 @@ public:
 	}
 
 	template<class BoardStatus status, int depth>
-	static _Inline void Pawnpromote(const Board& brd, uint64_t from, uint64_t to)
+	static void Pawnpromote(const Board& brd, uint64_t from, uint64_t to)
 	{
 		Board next1 = Board::MovePromote<BoardPiece::Queen, status.WhiteMove>(brd, from, to);
 		IFPRN std::cout << "Pawnpromote:\n" << _map(from, to, brd, next1) << "\n";
@@ -145,7 +145,7 @@ public:
 	}
 
 	template<class BoardStatus status, int depth>
-	static _Inline void Knightmove(const Board& brd, uint64_t from, uint64_t to)
+	static void Knightmove(const Board& brd, uint64_t from, uint64_t to)
 	{
 		Board next = Board::Move <BoardPiece::Knight, status.WhiteMove>(brd, from, to, to & Enemy<status.WhiteMove>(brd));
 		IFPRN std::cout << "Knightmove:\n" << _map(from, to, brd, next) << "\n";
@@ -156,7 +156,7 @@ public:
 	}
 
 	template<class BoardStatus status, int depth>
-	static _Inline void Bishopmove(const Board& brd, uint64_t from, uint64_t to)
+	static void Bishopmove(const Board& brd, uint64_t from, uint64_t to)
 	{
 		Board next = Board::Move <BoardPiece::Bishop, status.WhiteMove>(brd, from, to, to & Enemy<status.WhiteMove>(brd));
 		IFPRN std::cout << "Bishopmove:\n" << _map(from, to, brd, next) << "\n";
@@ -165,7 +165,7 @@ public:
 	}
 
 	template<class BoardStatus status, int depth>
-	static _Inline void Rookmove(const Board& brd, uint64_t from, uint64_t to)
+	static void Rookmove(const Board& brd, uint64_t from, uint64_t to)
 	{
 		Board next = Board::Move<BoardPiece::Rook, status.WhiteMove>(brd, from, to, to & Enemy<status.WhiteMove>(brd));
 		IFPRN std::cout << "Rookmove:\n" << _map(from, to, brd, next) << "\n";
@@ -179,7 +179,7 @@ public:
 	}
 
 	template<class BoardStatus status, int depth>
-	static _Inline void Queenmove(const Board& brd, uint64_t from, uint64_t to)
+	static void Queenmove(const Board& brd, uint64_t from, uint64_t to)
 	{
 		Board next = Board::Move<BoardPiece::Queen, status.WhiteMove>(brd, from, to, to & Enemy<status.WhiteMove>(brd));
 		IFPRN std::cout << "Queenmove:\n" << _map(from, to, brd, next) << "\n";

--- a/Gigantua/Gigantua.cpp
+++ b/Gigantua/Gigantua.cpp
@@ -31,17 +31,10 @@ public:
 	template<class BoardStatus status, int depth>
 	static _ForceInline void PerfT(Board& brd)
 	{
-		Movelist::EnumerateMoves<status, MoveReciever, depth>(brd);
-	}
-
-	//This method will see every position //Normal Inline - not forced - heavy recursion
-	template<class BoardStatus status, int depth>
-	static _ForceInline void RegisterMove(Board& brd)
-	{
-		if constexpr (depth == 2) {
+		if constexpr (depth == 1)
 			PerfT1<status>(brd);
-		}
-		else PerfT<status, depth - 1>(brd);
+		else
+			Movelist::EnumerateMoves<status, MoveReciever, depth>(brd);
 	}
 
 
@@ -57,7 +50,7 @@ public:
 		IFPRN std::cout << "Kingmove:\n" << _map(from, to, brd, next) << "\n";
 		//IFDBG Board::AssertBoardMove<status.WhiteMove>(brd, next, to & Enemy<status.WhiteMove>(brd));
 
-		RegisterMove<status.KingMove(), depth>(next);
+		PerfT<status.KingMove(), depth - 1>(next);
 	}
 
 	template<class BoardStatus status, int depth>
@@ -66,7 +59,7 @@ public:
 		Board next = Board::MoveCastle<status.WhiteMove>(brd, kingswitch, rookswitch);
 		IFPRN std::cout << "KingCastle:\n" << _map(kingswitch, rookswitch, brd, next) << "\n";
 		//IFDBG Board::AssertBoardMove<status.WhiteMove>(brd, next, false);
-		RegisterMove<status.KingMove(), depth>(next);
+		PerfT<status.KingMove(), depth - 1>(next);
 	}
 
 	template<class BoardStatus status, int depth>
@@ -93,7 +86,7 @@ public:
 		IFPRN std::cout << "Pawnmove:\n" << _map(from, to, brd, next) << "\n";
 		//IFDBG Board::AssertBoardMove<status.WhiteMove>(brd, next, to & Enemy<status.WhiteMove>(brd));
 		PawnCheck<status, depth>(EnemyKing<status.WhiteMove>(brd), to);
-		RegisterMove<status.SilentMove(), depth>(next);
+		PerfT<status.SilentMove(), depth - 1>(next);
 		Movestack::Check_Status[depth - 1] = 0xffffffffffffffffull;
 	}
 
@@ -104,7 +97,7 @@ public:
 		IFPRN std::cout << "Pawntake:\n" << _map(from, to, brd, next) << "\n";
 		//IFDBG Board::AssertBoardMove<status.WhiteMove>(brd, next, to & Enemy<status.WhiteMove>(brd));
 		PawnCheck<status, depth>(EnemyKing<status.WhiteMove>(brd), to);
-		RegisterMove<status.SilentMove(), depth>(next);
+		PerfT<status.SilentMove(), depth - 1>(next);
 		Movestack::Check_Status[depth - 1] = 0xffffffffffffffffull;
 	}
 
@@ -115,7 +108,7 @@ public:
 		IFPRN std::cout << "PawnEnpassantTake:\n" << _map(from | enemy, to, brd, next) << "\n";
 		//IFDBG Board::AssertBoardMove<status.WhiteMove>(brd, next, true);
 		PawnCheck<status, depth>(EnemyKing<status.WhiteMove>(brd), to);
-		RegisterMove<status.SilentMove(), depth>(next);
+		PerfT<status.SilentMove(), depth - 1>(next);
 		Movestack::Check_Status[depth - 1] = 0xffffffffffffffffull;
 	}
 
@@ -128,7 +121,7 @@ public:
 
 		Movelist::EnPassantTarget = to;
 		PawnCheck<status, depth>(EnemyKing<status.WhiteMove>(brd), to);
-		RegisterMove<status.PawnPush(), depth>(next);
+		PerfT<status.PawnPush(), depth - 1>(next);
 		Movestack::Check_Status[depth - 1] = 0xffffffffffffffffull;
 	}
 
@@ -138,17 +131,17 @@ public:
 		Board next1 = Board::MovePromote<BoardPiece::Queen, status.WhiteMove>(brd, from, to);
 		IFPRN std::cout << "Pawnpromote:\n" << _map(from, to, brd, next1) << "\n";
 		//IFDBG Board::AssertBoardMove<status.WhiteMove>(brd, next1, to & Enemy<status.WhiteMove>(brd));
-		RegisterMove<status.SilentMove(), depth>(next1);
+		PerfT<status.SilentMove(), depth - 1>(next1);
 
 		Board next2 = Board::MovePromote<BoardPiece::Knight, status.WhiteMove>(brd, from, to);
 		KnightCheck<status, depth>(EnemyKing<status.WhiteMove>(brd), to);
-		RegisterMove<status.SilentMove(), depth>(next2);
+		PerfT<status.SilentMove(), depth - 1>(next2);
 		Movestack::Check_Status[depth - 1] = 0xffffffffffffffffull;
 
 		Board next3 = Board::MovePromote<BoardPiece::Bishop, status.WhiteMove>(brd, from, to);
-		RegisterMove<status.SilentMove(), depth>(next3);
+		PerfT<status.SilentMove(), depth - 1>(next3);
 		Board next4 = Board::MovePromote<BoardPiece::Rook, status.WhiteMove>(brd, from, to);
-		RegisterMove<status.SilentMove(), depth>(next4);
+		PerfT<status.SilentMove(), depth - 1>(next4);
 	}
 
 	template<class BoardStatus status, int depth>
@@ -158,7 +151,7 @@ public:
 		IFPRN std::cout << "Knightmove:\n" << _map(from, to, brd, next) << "\n";
 		//IFDBG Board::AssertBoardMove<status.WhiteMove>(brd, next, to & Enemy<status.WhiteMove>(brd));
 		KnightCheck<status, depth>(EnemyKing<status.WhiteMove>(brd), to);
-		RegisterMove<status.SilentMove(), depth>(next);
+		PerfT<status.SilentMove(), depth - 1>(next);
 		Movestack::Check_Status[depth - 1] = 0xffffffffffffffffull;
 	}
 
@@ -168,7 +161,7 @@ public:
 		Board next = Board::Move <BoardPiece::Bishop, status.WhiteMove>(brd, from, to, to & Enemy<status.WhiteMove>(brd));
 		IFPRN std::cout << "Bishopmove:\n" << _map(from, to, brd, next) << "\n";
 		//IFDBG Board::AssertBoardMove<status.WhiteMove>(brd, next, to & Enemy<status.WhiteMove>(brd));
-		RegisterMove<status.SilentMove(), depth>(next);
+		PerfT<status.SilentMove(), depth - 1>(next);
 	}
 
 	template<class BoardStatus status, int depth>
@@ -178,11 +171,11 @@ public:
 		IFPRN std::cout << "Rookmove:\n" << _map(from, to, brd, next) << "\n";
 		//IFDBG Board::AssertBoardMove<status.WhiteMove>(brd, next, to & Enemy<status.WhiteMove>(brd));
 		if constexpr (status.CanCastle()) {
-			if (status.IsLeftRook(from)) RegisterMove<status.RookMove_Left(), depth>(next);
-			else if (status.IsRightRook(from)) RegisterMove<status.RookMove_Right(), depth>(next);
-			else RegisterMove<status.SilentMove(), depth>(next);
+			if (status.IsLeftRook(from)) PerfT<status.RookMove_Left(), depth - 1>(next);
+			else if (status.IsRightRook(from)) PerfT<status.RookMove_Right(), depth - 1>(next);
+			else PerfT<status.SilentMove(), depth - 1>(next);
 		}
-		else RegisterMove<status.SilentMove(), depth>(next);
+		else PerfT<status.SilentMove(), depth - 1>(next);
 	}
 
 	template<class BoardStatus status, int depth>
@@ -191,7 +184,7 @@ public:
 		Board next = Board::Move<BoardPiece::Queen, status.WhiteMove>(brd, from, to, to & Enemy<status.WhiteMove>(brd));
 		IFPRN std::cout << "Queenmove:\n" << _map(from, to, brd, next) << "\n";
 		//IFDBG Board::AssertBoardMove<status.WhiteMove>(brd, next, to & Enemy<status.WhiteMove>(brd));
-		RegisterMove<status.SilentMove(), depth>(next);
+		PerfT<status.SilentMove(), depth - 1>(next);
 	}
 };
 

--- a/Gigantua/Movelist.hpp
+++ b/Gigantua/Movelist.hpp
@@ -291,9 +291,10 @@ namespace Movelist {
     }
 
     class VoidClass{};
-    template<class BoardStatus status, bool justcount, class Callback_Move, int depth>
+    template<class BoardStatus status, class Callback_Move, int depth>
     _ForceInline auto _enumerate(const Board& brd, map kingatk, const map kingban, const map checkmask)
     {
+        constexpr bool justcount = std::is_same_v<Callback_Move, VoidClass>;
         constexpr bool white = status.WhiteMove;
         const bool noCheck = (checkmask == 0xffffffffffffffffull);
         uint64_t movecnt = 0;
@@ -548,7 +549,7 @@ namespace Movelist {
         map kingatk = Refresh<status, depth>(brd, kingban, checkmask);
 
         if (checkmask != 0) {
-            _enumerate<status, false, Callback_Move, depth>(brd, kingatk, kingban, checkmask);
+            _enumerate<status, Callback_Move, depth>(brd, kingatk, kingban, checkmask);
         }
         else {
             Bitloop(kingatk)
@@ -568,7 +569,7 @@ namespace Movelist {
         map kingatk = Refresh<status, 1>(brd, kingban, checkmask);
          
         if (checkmask != 0)
-            return _enumerate<status, true, VoidClass, 1>(brd, kingatk, kingban, checkmask);  //one check
+            return _enumerate<status, VoidClass, 1>(brd, kingatk, kingban, checkmask);  //one check
         else
             return Bitcount(kingatk); //double check
     }


### PR DESCRIPTION
This PR halves the link time while maintaining the same run time performance.

The template parameter inCheck in _enumerate is false if and only if checkmask == 0xffffffffffffffffull.
So `inCheck = (checkmask != 0xffffffffffffffffull)`.

```
const map checkmask = ConstCheckmask<inCheck>(CheckMask);
const map movableSquare = MoveableSquares<white, inCheck>(brd, checkmask);
```
in _enumerate is equivalent to
```
map movableSquare;
if constexpr (inCheck) movableSquare = EnemyOrEmpty<white>(brd) & checkmask;
else movableSquare = EnemyOrEmpty<white>(brd);
```
which is equivalent to
```
map movableSquare;
if constexpr (checkmask != 0xffffffffffffffffull) movableSquare = EnemyOrEmpty<white>(brd) & checkmask;
else movableSquare =EnemyOrEmpty<white>(brd) & checkmask;
```
because in the else clause checkmask is 0xffffffffffffffffull, so the & does nothing.
The branching is now redundant and the code snipped is equivalent to
```
const map movableSquare = EnemyOrEmpty<white>(brd) & checkmask;
```

Also every call to _enumerate is surrounded by a run time branching which determines the template parameter inCheck. This branching can be pulled into _enumerate and the template parameter replaced by a local variable. For the sake of simplicity I called it noCheck. Testing shows this doesn't hurt run time performance.

The other commits just try to simplify the code. I hope it helps your productivity.
Great work!