### PR TITLE
perf: Unused value `i++`

### DIFF
--- a/Gigantua/Chess_Base.hpp
+++ b/Gigantua/Chess_Base.hpp
@@ -346,7 +346,7 @@ struct FEN {
         }
 
         //En Passant
-        char EorMinus = FEN[i++];
+        char EorMinus = FEN[i];
         if (EorMinus != '-') {
             if (wb == 'w') {
                 //Todo where to store Enpassant


### PR DESCRIPTION
Small optimization: `i` is not used in the rest of the function, so the increment isn't necessary.